### PR TITLE
filter_kubernetes: fix memory leak and allow configurable cache size

### DIFF
--- a/plugins/filter_kubernetes/kube_conf.c
+++ b/plugins/filter_kubernetes/kube_conf.c
@@ -40,6 +40,7 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *ins,
 {
     int off;
     int ret;
+    int cache_size = FLB_HASH_TABLE_SIZE;
     const char *url;
     const char *tmp;
     const char *p;
@@ -125,30 +126,35 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *ins,
         }
     }
 
+    /* Check if a custom cache size has been defined */
+    if (ctx->kube_meta_cache_size > 0) {
+        cache_size = ctx->kube_meta_cache_size;
+    }
+
     if (ctx->kube_meta_cache_ttl > 0) {
         ctx->hash_table = flb_hash_table_create_with_ttl(ctx->kube_meta_cache_ttl,
                                                          FLB_HASH_TABLE_EVICT_OLDER,
-                                                         FLB_HASH_TABLE_SIZE,
-                                                         FLB_HASH_TABLE_SIZE);
+                                                         cache_size,
+                                                         cache_size);
     }
     else {
         ctx->hash_table = flb_hash_table_create(FLB_HASH_TABLE_EVICT_RANDOM,
-                                                FLB_HASH_TABLE_SIZE,
-                                                FLB_HASH_TABLE_SIZE);
+                                                cache_size,
+                                                cache_size);
     }
 
     if (ctx->kube_meta_namespace_cache_ttl > 0) {
         ctx->namespace_hash_table = flb_hash_table_create_with_ttl(
                                             ctx->kube_meta_namespace_cache_ttl,
                                             FLB_HASH_TABLE_EVICT_OLDER,
-                                            FLB_HASH_TABLE_SIZE,
-                                            FLB_HASH_TABLE_SIZE);
+                                            cache_size,
+                                            cache_size);
     }
     else {
         ctx->namespace_hash_table = flb_hash_table_create(
                                             FLB_HASH_TABLE_EVICT_RANDOM,
-                                            FLB_HASH_TABLE_SIZE,
-                                            FLB_HASH_TABLE_SIZE);
+                                            cache_size,
+                                            cache_size);
     }
 
 
@@ -192,8 +198,8 @@ struct flb_kube *flb_kube_conf_create(struct flb_filter_instance *ins,
 
     ctx->aws_pod_service_hash_table = flb_hash_table_create_with_ttl(ctx->aws_pod_service_map_ttl,
                                        FLB_HASH_TABLE_EVICT_OLDER,
-                                       FLB_HASH_TABLE_SIZE,
-                                       FLB_HASH_TABLE_SIZE);
+                                       cache_size,
+                                       cache_size);
     if (!ctx->aws_pod_service_hash_table) {
         flb_kube_conf_destroy(ctx);
         return NULL;

--- a/plugins/filter_kubernetes/kube_conf.h
+++ b/plugins/filter_kubernetes/kube_conf.h
@@ -195,6 +195,7 @@ struct flb_kube {
     int kubelet_port;
 
     int kube_meta_cache_ttl;
+    int kube_meta_cache_size;
     int kube_meta_namespace_cache_ttl;
 
     /* Configuration used for enabling pod to service name mapping*/

--- a/plugins/filter_kubernetes/kube_meta.c
+++ b/plugins/filter_kubernetes/kube_meta.c
@@ -2296,7 +2296,7 @@ static inline int flb_kube_pod_meta_get(struct flb_kube *ctx,
 {
     int id;
     int ret;
-    const char *hash_meta_buf;
+    const char *hash_meta_buf = NULL;
     char *tmp_hash_meta_buf;
     size_t off = 0;
     size_t hash_meta_size;
@@ -2335,6 +2335,16 @@ static inline int flb_kube_pod_meta_get(struct flb_kube *ctx,
             flb_hash_table_get_by_id(ctx->hash_table, id, meta->cache_key,
                                      &hash_meta_buf, &hash_meta_size);
         }
+        else {
+            flb_plg_error(ctx->ins, "could not add metadata to the cache: %s",
+                          meta->cache_key);
+            flb_free(tmp_hash_meta_buf);
+            return -1;
+        }
+    }
+
+    if (!hash_meta_buf) {
+        return -1;
     }
 
     /*
@@ -2375,7 +2385,7 @@ static inline int flb_kube_namespace_meta_get(struct flb_kube *ctx,
 {
     int id;
     int ret;
-    const char *hash_meta_buf;
+    const char *hash_meta_buf = NULL;
     char *tmp_hash_meta_buf;
     size_t off = 0;
     size_t hash_meta_size;
@@ -2414,6 +2424,16 @@ static inline int flb_kube_namespace_meta_get(struct flb_kube *ctx,
             flb_hash_table_get_by_id(ctx->namespace_hash_table, id, meta->cache_key,
                                      &hash_meta_buf, &hash_meta_size);
         }
+        else {
+            flb_plg_error(ctx->ins, "could not add namespace metadata to the cache: %s",
+                          meta->cache_key);
+            flb_free(tmp_hash_meta_buf);
+            return -1;
+        }
+    }
+
+    if (!hash_meta_buf) {
+        return -1;
     }
 
     /*

--- a/plugins/filter_kubernetes/kubernetes.c
+++ b/plugins/filter_kubernetes/kubernetes.c
@@ -1114,12 +1114,18 @@ static struct flb_config_map config_map[] = {
     {
      FLB_CONFIG_MAP_TIME, "kube_meta_cache_ttl", "0",
      0, FLB_TRUE, offsetof(struct flb_kube, kube_meta_cache_ttl),
-     "configurable TTL for K8s cached metadata. " 
-     "By default, it is set to 0 which means TTL for cache entries is disabled and " 
-     "cache entries are evicted at random when capacity is reached. " 
-     "In order to enable this option, you should set the number to a time interval. " 
-     "For example, set this value to 60 or 60s and cache entries " 
+     "configurable TTL for K8s cached metadata. "
+     "By default, it is set to 0 which means TTL for cache entries is disabled and "
+     "cache entries are evicted at random when capacity is reached. "
+     "In order to enable this option, you should set the number to a time interval. "
+     "For example, set this value to 60 or 60s and cache entries "
      "which have been created more than 60s will be evicted"
+    },
+    {
+     FLB_CONFIG_MAP_INT, "kube_meta_cache_size", "0",
+     0, FLB_TRUE, offsetof(struct flb_kube, kube_meta_cache_size),
+     "configurable size for K8s cached metadata hash table. "
+     "By default, it is set to 0 which means the default size (256) is used."
     },
     {
      FLB_CONFIG_MAP_TIME, "kube_meta_namespace_cache_ttl", "15m",


### PR DESCRIPTION
This commit addresses a memory leak issue and unbounded cache growth in the kubernetes filter plugin.

Changes:
- Add `kube_meta_cache_size` configuration option. This allows users to configure the size of the metadata cache hash table.
- Update `kube_conf.c` to use the configured cache size for initialization.
- Fix memory leak in `kube_meta.c` where `tmp_hash_meta_buf` was not freed if `flb_hash_table_add` failed in `flb_kube_pod_meta_get` and `flb_kube_namespace_meta_get`.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
